### PR TITLE
Add client-api-proxy

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -430,6 +430,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "client-api-proxy"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.22.0",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1763,7 @@ name = "pos-install"
 version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.22.0",
+ "client-api-proxy 0.1.0",
  "pos 0.1.0",
 ]
 

--- a/execution-engine/contracts/system/client-api-proxy/Cargo.toml
+++ b/execution-engine/contracts/system/client-api-proxy/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "client-api-proxy"
+version = "0.1.0"
+authors = ["joonho <jhyeom26@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+lib = []
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/system/client-api-proxy/src/client_api/error.rs
+++ b/execution-engine/contracts/system/client-api-proxy/src/client_api/error.rs
@@ -1,0 +1,12 @@
+use contract_ffi::contract_api::Error as ApiError;
+
+#[repr(u16)]
+pub enum Error {
+    UnknownProxyApi = 1, // 65537
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> ApiError {
+        ApiError::User(error as u16)
+    }
+}

--- a/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
+++ b/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
@@ -11,22 +11,22 @@ use contract_ffi::{
 use error::Error;
 
 mod proxy_method_names {
-    pub const BOND: &str = "bond";
-    pub const UNBOND: &str = "unbond";
+    use super::internal_method_names;
+
+    pub const BOND: &str = internal_method_names::BOND;
+    pub const UNBOND: &str = internal_method_names::UNBOND;
     pub const TRANSFER_TO_ACCOUNT: &str = "transfer_to_account";
 }
 
 mod internal_method_names {
-    use super::proxy_method_names;
-
-    pub const BOND: &str = proxy_method_names::BOND;
-    pub const UNBOND: &str = proxy_method_names::UNBOND;
+    pub const BOND: &str = "bond";
+    pub const UNBOND: &str = "unbond";
 }
 
 pub enum Api {
     Bond(u64),
     Unbond(Option<u64>),
-    TransferToAccount(PublicKey, U512),
+    TransferToAccount(PublicKey, u64),
 }
 
 impl Api {
@@ -56,7 +56,7 @@ impl Api {
                     .unwrap_or_revert_with(ApiError::MissingArgument)
                     .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-                Api::TransferToAccount(public_key, transfer_amount.into())
+                Api::TransferToAccount(public_key, transfer_amount)
             }
             _ => runtime::revert(Error::UnknownProxyApi),
         }
@@ -82,10 +82,10 @@ impl Api {
             Self::Unbond(amount) => {
                 let pos_ref = system::get_proof_of_stake();
                 let amount: Option<U512> = amount.map(Into::into);
-                runtime::call_contract(pos_ref.clone(), (internal_method_names::UNBOND, amount))
+                runtime::call_contract(pos_ref, (internal_method_names::UNBOND, amount))
             }
             Self::TransferToAccount(public_key, amount) => {
-                system::transfer_to_account(*public_key, *amount).unwrap_or_revert();
+                system::transfer_to_account(*public_key, (*amount).into()).unwrap_or_revert();
             }
         }
     }

--- a/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
+++ b/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
@@ -74,18 +74,15 @@ impl Api {
                 system::transfer_from_purse_to_purse(source_purse, bonding_purse, amount)
                     .unwrap_or_revert();
 
-                runtime::call_contract::<_, ()>(
-                    pos_ref.clone(),
+                runtime::call_contract(
+                    pos_ref,
                     (internal_method_names::BOND, amount, bonding_purse),
-                );
+                )
             }
             Self::Unbond(amount) => {
                 let pos_ref = system::get_proof_of_stake();
                 let amount: Option<U512> = amount.map(Into::into);
-                runtime::call_contract::<_, ()>(
-                    pos_ref.clone(),
-                    (internal_method_names::UNBOND, amount),
-                );
+                runtime::call_contract(pos_ref.clone(), (internal_method_names::UNBOND, amount))
             }
             Self::TransferToAccount(public_key, amount) => {
                 system::transfer_to_account(*public_key, *amount).unwrap_or_revert();

--- a/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
+++ b/execution-engine/contracts/system/client-api-proxy/src/client_api/mod.rs
@@ -1,0 +1,95 @@
+mod error;
+
+use alloc::string::String;
+
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
+
+use error::Error;
+
+mod proxy_method_names {
+    pub const BOND: &str = "bond";
+    pub const UNBOND: &str = "unbond";
+    pub const TRANSFER_TO_ACCOUNT: &str = "transfer_to_account";
+}
+
+mod internal_method_names {
+    use super::proxy_method_names;
+
+    pub const BOND: &str = proxy_method_names::BOND;
+    pub const UNBOND: &str = proxy_method_names::UNBOND;
+}
+
+pub enum Api {
+    Bond(u64),
+    Unbond(Option<u64>),
+    TransferToAccount(PublicKey, U512),
+}
+
+impl Api {
+    pub fn from_args() -> Self {
+        let method_name: String = runtime::get_arg(0)
+            .unwrap_or_revert_with(ApiError::MissingArgument)
+            .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+        match method_name.as_str() {
+            proxy_method_names::BOND => {
+                let amount: u64 = runtime::get_arg(1)
+                    .unwrap_or_revert_with(ApiError::MissingArgument)
+                    .unwrap_or_revert_with(ApiError::InvalidArgument);
+                Api::Bond(amount)
+            }
+            proxy_method_names::UNBOND => {
+                let amount: Option<u64> = runtime::get_arg(1)
+                    .unwrap_or_revert_with(ApiError::MissingArgument)
+                    .unwrap_or_revert_with(ApiError::InvalidArgument);
+                Api::Unbond(amount)
+            }
+            proxy_method_names::TRANSFER_TO_ACCOUNT => {
+                let public_key: PublicKey = runtime::get_arg(1)
+                    .unwrap_or_revert_with(ApiError::MissingArgument)
+                    .unwrap_or_revert_with(ApiError::InvalidArgument);
+                let transfer_amount: u64 = runtime::get_arg(2)
+                    .unwrap_or_revert_with(ApiError::MissingArgument)
+                    .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+                Api::TransferToAccount(public_key, transfer_amount.into())
+            }
+            _ => runtime::revert(Error::UnknownProxyApi),
+        }
+    }
+
+    pub fn invoke(&self) {
+        match self {
+            Self::Bond(amount) => {
+                let pos_ref = system::get_proof_of_stake();
+                let amount: U512 = (*amount).into();
+
+                let source_purse = account::get_main_purse();
+                let bonding_purse = system::create_purse();
+
+                system::transfer_from_purse_to_purse(source_purse, bonding_purse, amount)
+                    .unwrap_or_revert();
+
+                runtime::call_contract::<_, ()>(
+                    pos_ref.clone(),
+                    (internal_method_names::BOND, amount, bonding_purse),
+                );
+            }
+            Self::Unbond(amount) => {
+                let pos_ref = system::get_proof_of_stake();
+                let amount: Option<U512> = amount.map(Into::into);
+                runtime::call_contract::<_, ()>(
+                    pos_ref.clone(),
+                    (internal_method_names::UNBOND, amount),
+                );
+            }
+            Self::TransferToAccount(public_key, amount) => {
+                system::transfer_to_account(*public_key, *amount).unwrap_or_revert();
+            }
+        }
+    }
+}

--- a/execution-engine/contracts/system/client-api-proxy/src/lib.rs
+++ b/execution-engine/contracts/system/client-api-proxy/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+extern crate alloc;
+
+mod client_api;
+
+use contract_ffi::contract_api::{runtime, storage};
+
+use client_api::Api;
+
+const CLIENT_API_PROXY_NAME: &str = "client_api_proxy";
+
+#[no_mangle]
+pub extern "C" fn client_api_proxy() {
+    Api::from_args().invoke();
+}
+
+pub fn deploy_client_api_proxy() {
+    let contract_hash = storage::store_function_at_hash(CLIENT_API_PROXY_NAME, Default::default());
+    runtime::put_key(CLIENT_API_PROXY_NAME, contract_hash.into());
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    deploy_client_api_proxy();
+}

--- a/execution-engine/contracts/system/pos-install/Cargo.toml
+++ b/execution-engine/contracts/system/pos-install/Cargo.toml
@@ -17,3 +17,4 @@ std = ["contract-ffi/std"]
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
 pos = { path = "../pos", default-features = false, features = ["lib"] }
+client-api-proxy = { path = "../client-api-proxy", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -87,6 +87,9 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::UnexpectedContractRefVariant);
     let return_value = CLValue::from_t(uref).unwrap_or_revert();
 
+    // store a contract which serves as proxy for commonly used client apis.
+    client_api_proxy::deploy_client_api_proxy();
+
     runtime::ret(return_value);
 }
 

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -65,7 +65,7 @@ use crate::{
         query::{QueryRequest, QueryResult},
         upgrade::{UpgradeConfig, UpgradeResult},
     },
-    execution::{self, AddressGenerator, Executor, MINT_NAME, POS_NAME},
+    execution::{self, AddressGenerator, Executor, CLIENT_API_PROXY_NAME, MINT_NAME, POS_NAME},
     tracking_copy::{TrackingCopy, TrackingCopyExt},
     KnownKeys,
 };
@@ -312,11 +312,24 @@ where
             ret
         };
 
+        let client_api_proxy_hash = tracking_copy
+            .borrow_mut()
+            .get_account(correlation_id, SYSTEM_ACCOUNT_ADDR)?
+            .named_keys()
+            .get(CLIENT_API_PROXY_NAME)
+            .expect("System Account should have client_api_proxy hash")
+            .as_hash()
+            .expect("should be hash");
+
         // Create known keys for system account
         let system_account_named_keys = {
             let mut ret = BTreeMap::new();
             ret.insert(MINT_NAME.to_string(), Key::URef(mint_reference));
             ret.insert(POS_NAME.to_string(), Key::URef(proof_of_stake_reference));
+            ret.insert(
+                CLIENT_API_PROXY_NAME.to_string(),
+                Key::Hash(client_api_proxy_hash),
+            );
             ret
         };
 

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -18,5 +18,6 @@ pub use self::{
 
 pub const MINT_NAME: &str = "mint";
 pub const POS_NAME: &str = "pos";
+pub const CLIENT_API_PROXY_NAME: &str = "client_api_proxy";
 
 pub(crate) const FN_STORE_ID_INITIAL: u32 = 0;

--- a/execution-engine/engine-tests/src/test/system_contracts/client_api_proxy.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/client_api_proxy.rs
@@ -1,23 +1,24 @@
-use contract_ffi::{key::Key, value::U512};
-use engine_core::engine_state::SYSTEM_ACCOUNT_ADDR;
-use engine_shared::stored_value::StoredValue;
+use base16;
+
+use contract_ffi::{
+    key::Key,
+    value::{account::PublicKey, U512},
+};
+use engine_core::engine_state::{genesis::GenesisAccount, SYSTEM_ACCOUNT_ADDR};
+use engine_shared::{motes::Motes, stored_value::StoredValue, transform::Transform};
 
 use crate::{
-    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
-    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+    support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG},
 };
 
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
 
-#[ignore]
-#[test]
-fn should_invoke_successfully_transfer_to_account() {
-    const TRANSFER_AMOUNT: u64 = 1000;
-    const TRANSFER_TO_ACCOUNT_METHOD: &str = "transfer_to_account";
+const TRANSFER_TO_ACCOUNT_METHOD: &str = "transfer_to_account";
+const BOND_METHOD: &str = "bond";
+const UNBOND_METHOD: &str = "unbond";
 
-    let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG).commit();
-
+fn get_client_api_proxy_hash(builder: &InMemoryWasmTestBuilder) -> [u8; 32] {
     // query client_api_proxy_hash from SYSTEM_ACCOUNT
     let system_account = match builder
         .query(None, Key::Account(SYSTEM_ACCOUNT_ADDR), &[])
@@ -27,12 +28,23 @@ fn should_invoke_successfully_transfer_to_account() {
         _ => panic!("should get an account"),
     };
 
-    let client_api_proxy_hash = system_account
+    system_account
         .named_keys()
         .get("client_api_proxy")
         .expect("should get client_api_proxy key")
         .as_hash()
-        .expect("should be hash");
+        .expect("should be hash")
+}
+
+#[ignore]
+#[test]
+fn should_invoke_successful_transfer_to_account() {
+    const TRANSFER_AMOUNT: u64 = 1000;
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG).commit();
+
+    let client_api_proxy_hash = get_client_api_proxy_hash(&builder);
 
     // transfer to ACCOUNT_1_ADDR with TRANSFER_AMOUNT
     let exec_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -54,4 +66,119 @@ fn should_invoke_successfully_transfer_to_account() {
         .get_purse_balance(account_1.purse_id());
 
     assert_eq!(balance, U512::from(TRANSFER_AMOUNT));
+}
+
+#[ignore]
+#[test]
+fn should_invoke_successful_bond_and_unbond() {
+    const BOND_AMOUNT: u64 = 1_000_000;
+
+    // only DEFAULT_ACCOUNT is in initial validator queue.
+    let accounts: Vec<GenesisAccount> = vec![GenesisAccount::new(
+        PublicKey::new(DEFAULT_ACCOUNT_ADDR),
+        Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+        Motes::new(BOND_AMOUNT.into()),
+    )];
+    let genesis_config = test_support::create_genesis_config(accounts);
+    let result = InMemoryWasmTestBuilder::default()
+        .run_genesis(&genesis_config)
+        .commit()
+        .finish();
+
+    let client_api_proxy_hash = get_client_api_proxy_hash(result.builder());
+
+    // Transfer to ACCOUNT_1_ADDR request
+    let exec_request_transfer = ExecuteRequestBuilder::contract_call_by_hash(
+        DEFAULT_ACCOUNT_ADDR,
+        client_api_proxy_hash,
+        (
+            TRANSFER_TO_ACCOUNT_METHOD,
+            ACCOUNT_1_ADDR,
+            1_000_000_000 as u64,
+        ),
+    )
+    .build();
+    // Bonding request
+    let exec_request_bonding = ExecuteRequestBuilder::contract_call_by_hash(
+        ACCOUNT_1_ADDR,
+        client_api_proxy_hash,
+        (BOND_METHOD, BOND_AMOUNT),
+    )
+    .build();
+    let bonding_result = InMemoryWasmTestBuilder::from_result(result)
+        .exec(exec_request_transfer)
+        .expect_success()
+        .commit()
+        .exec(exec_request_bonding)
+        .expect_success()
+        .commit()
+        .finish();
+
+    let pos_uref = bonding_result.builder().get_pos_contract_uref();
+
+    // retrieve transform of bond request.
+    let transforms = &bonding_result.builder().get_transforms()[1];
+    let pos_transform = &transforms[&Key::from(pos_uref).normalize()];
+
+    let pos_contract = if let Transform::Write(StoredValue::Contract(contract)) = pos_transform {
+        contract
+    } else {
+        panic!(
+            "pos transform is expected to be of AddKeys variant but received {:?}",
+            pos_transform
+        );
+    };
+
+    let lookup_key = format!(
+        "v_{}_{}",
+        base16::encode_lower(&ACCOUNT_1_ADDR),
+        BOND_AMOUNT
+    );
+    assert!(pos_contract.named_keys().contains_key(&lookup_key));
+
+    // Unbonding request
+    let exec_request_unbonding = ExecuteRequestBuilder::contract_call_by_hash(
+        ACCOUNT_1_ADDR,
+        client_api_proxy_hash,
+        (UNBOND_METHOD, None as Option<u64>), // None means unbond all the amount
+    )
+    .build();
+    let unbonding_result = InMemoryWasmTestBuilder::from_result(bonding_result)
+        .exec(exec_request_unbonding)
+        .expect_success()
+        .commit()
+        .finish();
+
+    let transforms = &unbonding_result.builder().get_transforms()[0];
+    let pos_transform = &transforms[&Key::from(pos_uref).normalize()];
+
+    let pos_contract = if let Transform::Write(StoredValue::Contract(contract)) = pos_transform {
+        contract
+    } else {
+        panic!(
+            "pos transform is expected to be of AddKeys variant but received {:?}",
+            pos_transform
+        );
+    };
+
+    // ensure that ACCOUNT_1_ADDR is not in validator queue.
+    assert_eq!(
+        pos_contract
+            .named_keys()
+            .iter()
+            .filter(
+                |(key, _)| key.starts_with(&format!("v_{}", base16::encode_lower(&ACCOUNT_1_ADDR)))
+            )
+            .count(),
+        0
+    );
+    // only genesis validator is still in the queue
+    assert_eq!(
+        pos_contract
+            .named_keys()
+            .iter()
+            .filter(|(key, _)| key.starts_with("v_"))
+            .count(),
+        1
+    );
 }

--- a/execution-engine/engine-tests/src/test/system_contracts/client_api_proxy.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/client_api_proxy.rs
@@ -1,0 +1,57 @@
+use contract_ffi::{key::Key, value::U512};
+use engine_core::engine_state::SYSTEM_ACCOUNT_ADDR;
+use engine_shared::stored_value::StoredValue;
+
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
+
+const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
+
+#[ignore]
+#[test]
+fn should_invoke_successfully_transfer_to_account() {
+    const TRANSFER_AMOUNT: u64 = 1000;
+    const TRANSFER_TO_ACCOUNT_METHOD: &str = "transfer_to_account";
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG).commit();
+
+    // query client_api_proxy_hash from SYSTEM_ACCOUNT
+    let system_account = match builder
+        .query(None, Key::Account(SYSTEM_ACCOUNT_ADDR), &[])
+        .expect("should query system account")
+    {
+        StoredValue::Account(account) => account,
+        _ => panic!("should get an account"),
+    };
+
+    let client_api_proxy_hash = system_account
+        .named_keys()
+        .get("client_api_proxy")
+        .expect("should get client_api_proxy key")
+        .as_hash()
+        .expect("should be hash");
+
+    // transfer to ACCOUNT_1_ADDR with TRANSFER_AMOUNT
+    let exec_request = ExecuteRequestBuilder::contract_call_by_hash(
+        DEFAULT_ACCOUNT_ADDR,
+        client_api_proxy_hash,
+        (TRANSFER_TO_ACCOUNT_METHOD, ACCOUNT_1_ADDR, TRANSFER_AMOUNT),
+    )
+    .build();
+
+    let test_result = builder.exec_commit_finish(exec_request);
+
+    let account_1 = test_result
+        .builder()
+        .get_account(ACCOUNT_1_ADDR)
+        .expect("should get account 1");
+
+    let balance = test_result
+        .builder()
+        .get_purse_balance(account_1.purse_id());
+
+    assert_eq!(balance, U512::from(TRANSFER_AMOUNT));
+}

--- a/execution-engine/engine-tests/src/test/system_contracts/mod.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+pub mod client_api_proxy;
+#[cfg(test)]
 pub mod genesis;
 #[cfg(test)]
 mod mint_install;

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -101,6 +101,19 @@ fn should_run_pos_install_contract() {
 
     let rewards_purse_balance = builder.get_purse_balance(rewards_purse);
     assert_eq!(rewards_purse_balance, U512::zero());
+
+    // system account should have a client_api_proxy contract in named_keys as Key::Hash
+    let query_result = builder
+        .query(None, Key::Account(SYSTEM_ADDR), &[])
+        .expect("should query system account");
+    let system_account = query_result
+        .as_account()
+        .expect("query result should be an account");
+
+    assert!(
+        system_account.named_keys().contains_key("client_api_proxy"),
+        "client_api_proxy should be present"
+    );
 }
 
 fn get_purse(named_keys: &BTreeMap<String, Key>, name: &str) -> Option<PurseId> {


### PR DESCRIPTION
We introduce the `client_api_proxy` contract installed at genesis.
The `client_api_proxy` contract allows users to request basic operations without a transient session code.

Available operations are listed below
```
bond(amount: u64)
unbond(amount: Option<u64>)
transfer_to_account(target_account: PublicKey, amount: u64)
```
How to use?

The `client_api_proxy` is stored under hash in SYSTEM ACCOUNT named_keys.
If you want to use, first, query the SYSTEM ACCOUNT named_keys,

```
casperlabs-client \
--host localhost \
query-state \
-t address \
--block-hash "put the block hash" \
-k 0000000000000000000000000000000000000000000000000000000000000000 -p ""
```

and retrieve the hash value of `client_api_proxy`. Then you can request like below

```
casperlabs-client \
    --host localhost \
    deploy \
    --from 929edd8d841e7a55fba4a5a3c4f3fa057a8d229cd1e27375efe64ee9743a6d3e \
    --session-hash "9fd0c4af965d6702d2309dc791e95913097de1da113436622458826629378cc7" \
    --session-args '[{"name": "method", "value": {"string_value": "bond"}},{"name": "amount", "value": {"long_value": 1000000}}]' \
    --payment $TEST_CONTRACT_DIR/standard_payment.wasm \
    --payment-args '[{"name":"amount", "value": {"big_int": {"value":"100000000", "bit_width": 512}}}]' \
    --private-key /path/to/keys/validator-private.pem
```
