### PR TITLE
Introduce queue in PoP

### DIFF
--- a/execution-engine/contracts/hdac-system/pop/src/constants.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/constants.rs
@@ -1,6 +1,7 @@
 pub(crate) mod local_keys {
-    pub const UNDELEGATE_REQUEST_QUEUE: u8 = 1;
-    pub const REDELEGATE_REQUEST_QUEUE: u8 = 2;
+    pub const DELEGATE_REQUEST_QUEUE: u8 = 1;
+    pub const UNDELEGATE_REQUEST_QUEUE: u8 = 2;
+    pub const REDELEGATE_REQUEST_QUEUE: u8 = 3;
 }
 
 pub(crate) mod uref_names {

--- a/execution-engine/contracts/hdac-system/pop/src/constants.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/constants.rs
@@ -1,5 +1,6 @@
 pub(crate) mod local_keys {
     pub const UNDELEGATE_REQUEST_QUEUE: u8 = 1;
+    pub const REDELEGATE_REQUEST_QUEUE: u8 = 2;
 }
 
 pub(crate) mod uref_names {

--- a/execution-engine/contracts/hdac-system/pop/src/constants.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/constants.rs
@@ -1,6 +1,5 @@
 pub(crate) mod local_keys {
-    pub const BONDING_KEY: u8 = 1;
-    pub const UNBONDING_KEY: u8 = 2;
+    pub const UNDELEGATE_REQUEST_QUEUE: u8 = 1;
 }
 
 pub(crate) mod uref_names {

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
@@ -1,39 +1,45 @@
+use alloc::vec::Vec;
+use core::result;
+
 use contract::contract_api::storage;
 use proof_of_stake::{self, QueueProvider};
-use types::{account::PublicKey, U512};
+use types::{
+    account::PublicKey,
+    bytesrepr::{self, FromBytes, ToBytes},
+    CLType, CLTyped, U512,
+};
 
 use crate::{
-    constants::local_keys::UNDELEGATE_REQUEST_QUEUE,
-    request_queue::{Request, RequestQueue, RequestQueueEntry},
+    constants::local_keys::{REDELEGATE_REQUEST_QUEUE, UNDELEGATE_REQUEST_QUEUE},
+    request_queue::{Request, RequestQueue},
 };
 
 pub struct ContractQueue;
 
 impl ContractQueue {
     pub fn read_undelegate_requests() -> UndelegateRequestQueue {
-        todo!()
-        // storage::read_local(&UNDELEGATE_REQUEST_QUEUE)
-        //     .unwrap_or_default()
-        //     .unwrap_or_default()
+        storage::read_local(&UNDELEGATE_REQUEST_QUEUE)
+            .unwrap_or_default()
+            .unwrap_or_default()
     }
 
     pub fn read_redelegate_requests() -> RedelegateRequestQueue {
-        todo!()
-        // storage::read_local(&REDELEGATE_REQUEST_QUEUE)
-        //     .unwrap_or_default()
-        //     .unwrap_or_default()
+        storage::read_local(&REDELEGATE_REQUEST_QUEUE)
+            .unwrap_or_default()
+            .unwrap_or_default()
     }
 
     pub fn write_undelegate_requests(queue: UndelegateRequestQueue) {
-        // storage::write_local(UNDELEGATE_REQUEST_QUEUE, queue);
+        storage::write_local(UNDELEGATE_REQUEST_QUEUE, queue);
     }
 
     pub fn write_redelegate_requests(queue: RedelegateRequestQueue) {
-        // storage::write_local(REDELEGATE_REQUEST_QUEUE, queue);
+        storage::write_local(REDELEGATE_REQUEST_QUEUE, queue);
     }
 }
 
 type UndelegateRequestQueue = RequestQueue<UndelegateRequest>;
+type RedelegateRequestQueue = RequestQueue<RedelegateRequest>;
 
 #[derive(Clone, Copy)]
 pub struct UndelegateRequest {
@@ -42,13 +48,46 @@ pub struct UndelegateRequest {
     pub amount: U512,
 }
 
+impl Default for RequestQueue<UndelegateRequest> {
+    fn default() -> Self {
+        RequestQueue::<UndelegateRequest> { 0: Vec::new() }
+    }
+}
+
 impl Request for UndelegateRequest {
     fn is_same(&self, rhs: &Self) -> bool {
         self.delegator == rhs.delegator && self.validator == rhs.validator
     }
 }
 
-type RedelegateRequestQueue = RequestQueue<RedelegateRequest>;
+impl FromBytes for UndelegateRequest {
+    fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
+        let (delegator, bytes) = PublicKey::from_bytes(bytes)?;
+        let (validator, bytes) = PublicKey::from_bytes(bytes)?;
+        let (amount, bytes) = U512::from_bytes(bytes)?;
+        let entry = UndelegateRequest {
+            delegator,
+            validator,
+            amount,
+        };
+        Ok((entry, bytes))
+    }
+}
+
+impl ToBytes for UndelegateRequest {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        Ok((self.delegator.to_bytes()?.into_iter())
+            .chain(self.validator.to_bytes()?)
+            .chain(self.amount.to_bytes()?)
+            .collect())
+    }
+}
+
+impl CLTyped for UndelegateRequest {
+    fn cl_type() -> CLType {
+        CLType::Any
+    }
+}
 
 #[derive(Clone, Copy)]
 pub struct RedelegateRequest {
@@ -58,11 +97,49 @@ pub struct RedelegateRequest {
     pub amount: U512,
 }
 
+impl Default for RequestQueue<RedelegateRequest> {
+    fn default() -> Self {
+        RequestQueue::<RedelegateRequest> { 0: Vec::new() }
+    }
+}
+
 impl Request for RedelegateRequest {
     fn is_same(&self, rhs: &Self) -> bool {
         self.delegator == rhs.delegator
             && self.src_validator == rhs.src_validator
             && self.dest_validator == rhs.dest_validator
+    }
+}
+
+impl FromBytes for RedelegateRequest {
+    fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
+        let (delegator, bytes) = PublicKey::from_bytes(bytes)?;
+        let (src_validator, bytes) = PublicKey::from_bytes(bytes)?;
+        let (dest_validator, bytes) = PublicKey::from_bytes(bytes)?;
+        let (amount, bytes) = U512::from_bytes(bytes)?;
+        let entry = RedelegateRequest {
+            delegator,
+            src_validator,
+            dest_validator,
+            amount,
+        };
+        Ok((entry, bytes))
+    }
+}
+
+impl ToBytes for RedelegateRequest {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        Ok((self.delegator.to_bytes()?.into_iter())
+            .chain(self.src_validator.to_bytes()?)
+            .chain(self.dest_validator.to_bytes()?)
+            .chain(self.amount.to_bytes()?)
+            .collect())
+    }
+}
+
+impl CLTyped for RedelegateRequest {
+    fn cl_type() -> CLType {
+        CLType::Any
     }
 }
 

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
@@ -1,7 +1,11 @@
 use contract::contract_api::storage;
 use proof_of_stake::{self, QueueProvider};
+use types::{account::PublicKey, U512};
 
-use crate::constants::local_keys::UNDELEGATE_REQUEST_QUEUE;
+use crate::{
+    constants::local_keys::UNDELEGATE_REQUEST_QUEUE,
+    request_queue::{Request, RequestQueue, RequestQueueEntry},
+};
 
 pub struct ContractQueue;
 
@@ -29,10 +33,38 @@ impl ContractQueue {
     }
 }
 
-#[derive(Clone, Default)]
-pub struct UndelegateRequestQueue;
-#[derive(Clone, Default)]
-pub struct RedelegateRequestQueue;
+type UndelegateRequestQueue = RequestQueue<UndelegateRequest>;
+
+#[derive(Clone, Copy)]
+pub struct UndelegateRequest {
+    pub delegator: PublicKey,
+    pub validator: PublicKey,
+    pub amount: U512,
+}
+
+impl Request for UndelegateRequest {
+    fn is_same(&self, rhs: &Self) -> bool {
+        self.delegator == rhs.delegator && self.validator == rhs.validator
+    }
+}
+
+type RedelegateRequestQueue = RequestQueue<RedelegateRequest>;
+
+#[derive(Clone, Copy)]
+pub struct RedelegateRequest {
+    pub delegator: PublicKey,
+    pub src_validator: PublicKey,
+    pub dest_validator: PublicKey,
+    pub amount: U512,
+}
+
+impl Request for RedelegateRequest {
+    fn is_same(&self, rhs: &Self) -> bool {
+        self.delegator == rhs.delegator
+            && self.src_validator == rhs.src_validator
+            && self.dest_validator == rhs.dest_validator
+    }
+}
 
 // TODO: remove QueueProvider
 // Currently, we are utilizing the default implemention of the Proof-of-Stake crate,

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue.rs
@@ -1,33 +1,56 @@
 use contract::contract_api::storage;
-use proof_of_stake::{Queue, QueueProvider};
+use proof_of_stake::{self, QueueProvider};
 
-use crate::constants::local_keys::{BONDING_KEY, UNBONDING_KEY};
+use crate::constants::local_keys::UNDELEGATE_REQUEST_QUEUE;
 
-/// A `QueueProvider` that reads and writes the queue to/from the contract's local state.
 pub struct ContractQueue;
 
+impl ContractQueue {
+    pub fn read_undelegate_requests() -> UndelegateRequestQueue {
+        todo!()
+        // storage::read_local(&UNDELEGATE_REQUEST_QUEUE)
+        //     .unwrap_or_default()
+        //     .unwrap_or_default()
+    }
+
+    pub fn read_redelegate_requests() -> RedelegateRequestQueue {
+        todo!()
+        // storage::read_local(&REDELEGATE_REQUEST_QUEUE)
+        //     .unwrap_or_default()
+        //     .unwrap_or_default()
+    }
+
+    pub fn write_undelegate_requests(queue: UndelegateRequestQueue) {
+        // storage::write_local(UNDELEGATE_REQUEST_QUEUE, queue);
+    }
+
+    pub fn write_redelegate_requests(queue: RedelegateRequestQueue) {
+        // storage::write_local(REDELEGATE_REQUEST_QUEUE, queue);
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct UndelegateRequestQueue;
+#[derive(Clone, Default)]
+pub struct RedelegateRequestQueue;
+
+// TODO: remove QueueProvider
+// Currently, we are utilizing the default implemention of the Proof-of-Stake crate,
+// so we need to add a dummy implemention to meet trait contraint.
 impl QueueProvider for ContractQueue {
-    /// Reads bonding queue from the local state of the contract.
-    fn read_bonding() -> Queue {
-        storage::read_local(&BONDING_KEY)
-            .unwrap_or_default()
-            .unwrap_or_default()
+    fn read_bonding() -> proof_of_stake::Queue {
+        unimplemented!()
     }
 
-    /// Reads unbonding queue from the local state of the contract.
-    fn read_unbonding() -> Queue {
-        storage::read_local(&UNBONDING_KEY)
-            .unwrap_or_default()
-            .unwrap_or_default()
+    fn read_unbonding() -> proof_of_stake::Queue {
+        unimplemented!()
     }
 
-    /// Writes bonding queue to the local state of the contract.
-    fn write_bonding(queue: Queue) {
-        storage::write_local(BONDING_KEY, queue);
+    fn write_bonding(_: proof_of_stake::Queue) {
+        unimplemented!()
     }
 
-    /// Writes unbonding queue to the local state of the contract.
-    fn write_unbonding(queue: Queue) {
-        storage::write_local(UNBONDING_KEY, queue);
+    fn write_unbonding(_: proof_of_stake::Queue) {
+        unimplemented!()
     }
 }

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/mod.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/mod.rs
@@ -5,7 +5,7 @@ use contract::contract_api::storage;
 use proof_of_stake::{self, QueueProvider};
 
 use request_queue::{Request, RequestQueue};
-pub use requests::{RedelegateRequest, UndelegateRequest};
+pub use requests::{DelegateRequest, RedelegateRequest, UndelegateRequest};
 
 pub struct ContractQueue;
 

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/mod.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/mod.rs
@@ -1,0 +1,42 @@
+mod request_queue;
+mod requests;
+
+use contract::contract_api::storage;
+use proof_of_stake::{self, QueueProvider};
+
+use request_queue::{Request, RequestQueue};
+pub use requests::{RedelegateRequest, UndelegateRequest};
+
+pub struct ContractQueue;
+
+impl ContractQueue {
+    pub fn read_requests<T: Request + Default>(key: [u8; 32]) -> RequestQueue<T> {
+        storage::read_local(&key)
+            .unwrap_or_default()
+            .unwrap_or_default()
+    }
+    pub fn write_requests<T: Request + Default>(key: [u8; 32], queue: RequestQueue<T>) {
+        storage::write_local(key, queue);
+    }
+}
+
+// TODO: remove QueueProvider
+// Currently, we are utilizing the default implemention of the Proof-of-Stake crate,
+// so we need to add a dummy implemention to meet trait contraint.
+impl QueueProvider for ContractQueue {
+    fn read_bonding() -> proof_of_stake::Queue {
+        unimplemented!()
+    }
+
+    fn read_unbonding() -> proof_of_stake::Queue {
+        unimplemented!()
+    }
+
+    fn write_bonding(_: proof_of_stake::Queue) {
+        unimplemented!()
+    }
+
+    fn write_unbonding(_: proof_of_stake::Queue) {
+        unimplemented!()
+    }
+}

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
@@ -7,6 +7,7 @@ use types::{
     BlockTime, CLType, CLTyped,
 };
 
+#[derive(Default)]
 pub struct RequestQueue<T: Request>(pub Vec<RequestQueueEntry<T>>);
 
 #[derive(Clone, Copy, Debug)]

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
@@ -7,16 +7,16 @@ use types::{
     BlockTime, CLType, CLTyped,
 };
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct RequestQueue<T: Request>(pub Vec<RequestQueueEntry<T>>);
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RequestQueueEntry<T: Request> {
     pub request: T,
     pub timestamp: BlockTime,
 }
 
-pub trait Request: Clone + Copy + FromBytes + ToBytes + CLTyped {
+pub trait Request: Clone + Copy + PartialEq + FromBytes + ToBytes + CLTyped {
     fn is_same(&self, rhs: &Self) -> bool;
 }
 

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/request_queue.rs
@@ -12,9 +12,9 @@ pub struct RequestQueue<T: RequestKey>(pub Vec<RequestQueueEntry<T>>);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RequestQueueEntry<T: RequestKey> {
-    request_key: T,
-    amount: U512,
-    timestamp: BlockTime,
+    pub request_key: T,
+    pub amount: U512,
+    pub timestamp: BlockTime,
 }
 
 impl<T: RequestKey> RequestQueueEntry<T> {

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
@@ -11,11 +11,31 @@ use super::request_queue::Request;
 
 pub type DelegateRequest = UndelegateRequest;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UndelegateRequest {
-    pub delegator: PublicKey,
-    pub validator: PublicKey,
-    pub amount: U512,
+    delegator: PublicKey,
+    validator: PublicKey,
+    amount: U512,
+}
+
+impl UndelegateRequest {
+    pub fn new(delegator: PublicKey, validator: PublicKey, amount: U512) -> Self {
+        UndelegateRequest {
+            delegator,
+            validator,
+            amount,
+        }
+    }
+}
+
+impl Default for UndelegateRequest {
+    fn default() -> Self {
+        UndelegateRequest {
+            delegator: PublicKey::from([0u8; 32]),
+            validator: PublicKey::from([0u8; 32]),
+            amount: U512::from(0),
+        }
+    }
 }
 
 impl Request for UndelegateRequest {
@@ -53,12 +73,39 @@ impl CLTyped for UndelegateRequest {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RedelegateRequest {
-    pub delegator: PublicKey,
-    pub src_validator: PublicKey,
-    pub dest_validator: PublicKey,
-    pub amount: U512,
+    delegator: PublicKey,
+    src_validator: PublicKey,
+    dest_validator: PublicKey,
+    amount: U512,
+}
+
+impl RedelegateRequest {
+    pub fn new(
+        delegator: PublicKey,
+        src_validator: PublicKey,
+        dest_validator: PublicKey,
+        amount: U512,
+    ) -> Self {
+        RedelegateRequest {
+            delegator,
+            src_validator,
+            dest_validator,
+            amount,
+        }
+    }
+}
+
+impl Default for RedelegateRequest {
+    fn default() -> Self {
+        RedelegateRequest {
+            delegator: PublicKey::from([0u8; 32]),
+            src_validator: PublicKey::from([0u8; 32]),
+            dest_validator: PublicKey::from([0u8; 32]),
+            amount: U512::from(0),
+        }
+    }
 }
 
 impl Request for RedelegateRequest {

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
@@ -1,57 +1,19 @@
 use alloc::vec::Vec;
 use core::result;
 
-use contract::contract_api::storage;
-use proof_of_stake::{self, QueueProvider};
 use types::{
     account::PublicKey,
     bytesrepr::{self, FromBytes, ToBytes},
     CLType, CLTyped, U512,
 };
 
-use crate::{
-    constants::local_keys::{REDELEGATE_REQUEST_QUEUE, UNDELEGATE_REQUEST_QUEUE},
-    request_queue::{Request, RequestQueue},
-};
-
-pub struct ContractQueue;
-
-impl ContractQueue {
-    pub fn read_undelegate_requests() -> UndelegateRequestQueue {
-        storage::read_local(&UNDELEGATE_REQUEST_QUEUE)
-            .unwrap_or_default()
-            .unwrap_or_default()
-    }
-
-    pub fn read_redelegate_requests() -> RedelegateRequestQueue {
-        storage::read_local(&REDELEGATE_REQUEST_QUEUE)
-            .unwrap_or_default()
-            .unwrap_or_default()
-    }
-
-    pub fn write_undelegate_requests(queue: UndelegateRequestQueue) {
-        storage::write_local(UNDELEGATE_REQUEST_QUEUE, queue);
-    }
-
-    pub fn write_redelegate_requests(queue: RedelegateRequestQueue) {
-        storage::write_local(REDELEGATE_REQUEST_QUEUE, queue);
-    }
-}
-
-type UndelegateRequestQueue = RequestQueue<UndelegateRequest>;
-type RedelegateRequestQueue = RequestQueue<RedelegateRequest>;
+use super::request_queue::Request;
 
 #[derive(Clone, Copy)]
 pub struct UndelegateRequest {
     pub delegator: PublicKey,
     pub validator: PublicKey,
     pub amount: U512,
-}
-
-impl Default for RequestQueue<UndelegateRequest> {
-    fn default() -> Self {
-        RequestQueue::<UndelegateRequest> { 0: Vec::new() }
-    }
 }
 
 impl Request for UndelegateRequest {
@@ -97,12 +59,6 @@ pub struct RedelegateRequest {
     pub amount: U512,
 }
 
-impl Default for RequestQueue<RedelegateRequest> {
-    fn default() -> Self {
-        RequestQueue::<RedelegateRequest> { 0: Vec::new() }
-    }
-}
-
 impl Request for RedelegateRequest {
     fn is_same(&self, rhs: &Self) -> bool {
         self.delegator == rhs.delegator
@@ -140,26 +96,5 @@ impl ToBytes for RedelegateRequest {
 impl CLTyped for RedelegateRequest {
     fn cl_type() -> CLType {
         CLType::Any
-    }
-}
-
-// TODO: remove QueueProvider
-// Currently, we are utilizing the default implemention of the Proof-of-Stake crate,
-// so we need to add a dummy implemention to meet trait contraint.
-impl QueueProvider for ContractQueue {
-    fn read_bonding() -> proof_of_stake::Queue {
-        unimplemented!()
-    }
-
-    fn read_unbonding() -> proof_of_stake::Queue {
-        unimplemented!()
-    }
-
-    fn write_bonding(_: proof_of_stake::Queue) {
-        unimplemented!()
-    }
-
-    fn write_unbonding(_: proof_of_stake::Queue) {
-        unimplemented!()
     }
 }

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
@@ -4,145 +4,118 @@ use core::result;
 use types::{
     account::PublicKey,
     bytesrepr::{self, FromBytes, ToBytes},
-    CLType, CLTyped, U512,
+    CLType, CLTyped,
 };
 
-use super::request_queue::Request;
+use super::request_queue::RequestKey;
 
-pub type DelegateRequest = UndelegateRequest;
+pub type DelegateRequestKey = UndelegateRequestKey;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UndelegateRequest {
-    delegator: PublicKey,
-    validator: PublicKey,
-    amount: U512,
+pub struct UndelegateRequestKey {
+    pub delegator: PublicKey,
+    pub validator: PublicKey,
 }
 
-impl UndelegateRequest {
-    pub fn new(delegator: PublicKey, validator: PublicKey, amount: U512) -> Self {
-        UndelegateRequest {
+impl UndelegateRequestKey {
+    pub fn new(delegator: PublicKey, validator: PublicKey) -> Self {
+        UndelegateRequestKey {
             delegator,
             validator,
-            amount,
         }
     }
 }
 
-impl Default for UndelegateRequest {
+impl Default for UndelegateRequestKey {
     fn default() -> Self {
-        UndelegateRequest {
+        UndelegateRequestKey {
             delegator: PublicKey::from([0u8; 32]),
             validator: PublicKey::from([0u8; 32]),
-            amount: U512::from(0),
         }
     }
 }
 
-impl Request for UndelegateRequest {
-    fn is_same(&self, rhs: &Self) -> bool {
-        self.delegator == rhs.delegator && self.validator == rhs.validator
-    }
-}
+impl RequestKey for UndelegateRequestKey {}
 
-impl FromBytes for UndelegateRequest {
+impl FromBytes for UndelegateRequestKey {
     fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
         let (delegator, bytes) = PublicKey::from_bytes(bytes)?;
         let (validator, bytes) = PublicKey::from_bytes(bytes)?;
-        let (amount, bytes) = U512::from_bytes(bytes)?;
-        let entry = UndelegateRequest {
+        let entry = UndelegateRequestKey {
             delegator,
             validator,
-            amount,
         };
         Ok((entry, bytes))
     }
 }
 
-impl ToBytes for UndelegateRequest {
+impl ToBytes for UndelegateRequestKey {
     fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
         Ok((self.delegator.to_bytes()?.into_iter())
             .chain(self.validator.to_bytes()?)
-            .chain(self.amount.to_bytes()?)
             .collect())
     }
 }
 
-impl CLTyped for UndelegateRequest {
+impl CLTyped for UndelegateRequestKey {
     fn cl_type() -> CLType {
         CLType::Any
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct RedelegateRequest {
-    delegator: PublicKey,
-    src_validator: PublicKey,
-    dest_validator: PublicKey,
-    amount: U512,
+pub struct RedelegateRequestKey {
+    pub delegator: PublicKey,
+    pub src_validator: PublicKey,
+    pub dest_validator: PublicKey,
 }
 
-impl RedelegateRequest {
-    pub fn new(
-        delegator: PublicKey,
-        src_validator: PublicKey,
-        dest_validator: PublicKey,
-        amount: U512,
-    ) -> Self {
-        RedelegateRequest {
+impl RedelegateRequestKey {
+    pub fn new(delegator: PublicKey, src_validator: PublicKey, dest_validator: PublicKey) -> Self {
+        RedelegateRequestKey {
             delegator,
             src_validator,
             dest_validator,
-            amount,
         }
     }
 }
 
-impl Default for RedelegateRequest {
+impl Default for RedelegateRequestKey {
     fn default() -> Self {
-        RedelegateRequest {
+        RedelegateRequestKey {
             delegator: PublicKey::from([0u8; 32]),
             src_validator: PublicKey::from([0u8; 32]),
             dest_validator: PublicKey::from([0u8; 32]),
-            amount: U512::from(0),
         }
     }
 }
 
-impl Request for RedelegateRequest {
-    fn is_same(&self, rhs: &Self) -> bool {
-        self.delegator == rhs.delegator
-            && self.src_validator == rhs.src_validator
-            && self.dest_validator == rhs.dest_validator
-    }
-}
+impl RequestKey for RedelegateRequestKey {}
 
-impl FromBytes for RedelegateRequest {
+impl FromBytes for RedelegateRequestKey {
     fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
         let (delegator, bytes) = PublicKey::from_bytes(bytes)?;
         let (src_validator, bytes) = PublicKey::from_bytes(bytes)?;
         let (dest_validator, bytes) = PublicKey::from_bytes(bytes)?;
-        let (amount, bytes) = U512::from_bytes(bytes)?;
-        let entry = RedelegateRequest {
+        let entry = RedelegateRequestKey {
             delegator,
             src_validator,
             dest_validator,
-            amount,
         };
         Ok((entry, bytes))
     }
 }
 
-impl ToBytes for RedelegateRequest {
+impl ToBytes for RedelegateRequestKey {
     fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
         Ok((self.delegator.to_bytes()?.into_iter())
             .chain(self.src_validator.to_bytes()?)
             .chain(self.dest_validator.to_bytes()?)
-            .chain(self.amount.to_bytes()?)
             .collect())
     }
 }
 
-impl CLTyped for RedelegateRequest {
+impl CLTyped for RedelegateRequestKey {
     fn cl_type() -> CLType {
         CLType::Any
     }

--- a/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_queue/requests.rs
@@ -9,6 +9,8 @@ use types::{
 
 use super::request_queue::Request;
 
+pub type DelegateRequest = UndelegateRequest;
+
 #[derive(Clone, Copy)]
 pub struct UndelegateRequest {
     pub delegator: PublicKey,

--- a/execution-engine/contracts/hdac-system/pop/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/lib.rs
@@ -10,7 +10,6 @@ mod contract_runtime;
 mod contract_stakes;
 mod contract_votes;
 mod pop_contract;
-mod request_queue;
 
 use alloc::string::String;
 
@@ -95,7 +94,8 @@ pub fn delegate() {
                 .finalize_payment(amount_spent, account)
                 .unwrap_or_revert();
         }
-        // Type of this method: `fn delegate(validator: PublicKey, amount: U512, src_purse_uref: URef)`
+        // Type of this method: `fn delegate(validator: PublicKey, amount: U512, src_purse_uref:
+        // URef)`
         methods::METHOD_DELEGATE => {
             let delegator = runtime::get_caller();
             let validator: PublicKey = runtime::get_arg(1)
@@ -124,7 +124,8 @@ pub fn delegate() {
                 .undelegate(delegator, validator, shares)
                 .unwrap_or_revert();
         }
-        // Type of this method: `fn redelegate(src_validator: PublicKey, dest_validator: PublicKey, amount: U512)`
+        // Type of this method: `fn redelegate(src_validator: PublicKey, dest_validator: PublicKey,
+        // amount: U512)`
         methods::METHOD_REDELEGATE => {
             let delegator: PublicKey = runtime::get_caller();
             let src_validator: PublicKey = runtime::get_arg(1)

--- a/execution-engine/contracts/hdac-system/pop/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/lib.rs
@@ -10,6 +10,7 @@ mod contract_runtime;
 mod contract_stakes;
 mod contract_votes;
 mod pop_contract;
+mod request_queue;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/hdac-system/pop/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/lib.rs
@@ -94,6 +94,7 @@ pub fn delegate() {
                 .finalize_payment(amount_spent, account)
                 .unwrap_or_revert();
         }
+        // Type of this method: `fn delegate(validator: PublicKey, amount: U512, src_purse_uref: URef)`
         methods::METHOD_DELEGATE => {
             let delegator = runtime::get_caller();
             let validator: PublicKey = runtime::get_arg(1)
@@ -109,6 +110,7 @@ pub fn delegate() {
                 .delegate(delegator, validator, amount, source_uref)
                 .unwrap_or_revert();
         }
+        // Type of this method: `fn undelegate(validator: PublicKey, amount: Option<U512>)`
         methods::METHOD_UNDELEGATE => {
             let delegator: PublicKey = runtime::get_caller();
             let validator: PublicKey = runtime::get_arg(1)
@@ -121,6 +123,7 @@ pub fn delegate() {
                 .undelegate(delegator, validator, shares)
                 .unwrap_or_revert();
         }
+        // Type of this method: `fn redelegate(src_validator: PublicKey, dest_validator: PublicKey, amount: U512)`
         methods::METHOD_REDELEGATE => {
             let delegator: PublicKey = runtime::get_caller();
             let src_validator: PublicKey = runtime::get_arg(1)

--- a/execution-engine/contracts/hdac-system/pop/src/request_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/request_queue.rs
@@ -1,0 +1,42 @@
+use alloc::vec::Vec;
+
+use types::{
+    system_contract_errors::pos::{Error, Result},
+    BlockTime,
+};
+
+#[derive(Clone, Default)]
+pub struct RequestQueue<T: Request + Clone + Copy>(pub Vec<RequestQueueEntry<T>>);
+
+#[derive(Clone, Copy, Debug)]
+pub struct RequestQueueEntry<T: Request + Clone + Copy> {
+    pub request: T,
+    pub timestamp: BlockTime,
+}
+
+pub trait Request {
+    fn is_same(&self, rhs: &Self) -> bool;
+}
+
+impl<T: Request + Clone + Copy> RequestQueue<T> {
+    pub fn push(&mut self, request: T, timestamp: BlockTime) -> Result<()> {
+        if self.0.iter().any(|entry| entry.request.is_same(&request)) {
+            return Err(Error::MultipleRequests);
+        }
+        if let Some(entry) = self.0.last() {
+            if entry.timestamp > timestamp {
+                return Err(Error::TimeWentBackwards);
+            }
+        }
+        self.0.push(RequestQueueEntry { request, timestamp });
+        Ok(())
+    }
+    pub fn pop_due(&mut self, timestamp: BlockTime) -> Vec<RequestQueueEntry<T>> {
+        let (older_than, rest) = self
+            .0
+            .iter()
+            .partition(|entry| entry.timestamp <= timestamp);
+        self.0 = rest;
+        older_than
+    }
+}

--- a/execution-engine/contracts/hdac-system/pop/src/request_queue.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/request_queue.rs
@@ -1,24 +1,25 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
+use core::result;
 
 use types::{
+    bytesrepr::{self, FromBytes, ToBytes},
     system_contract_errors::pos::{Error, Result},
-    BlockTime,
+    BlockTime, CLType, CLTyped,
 };
 
-#[derive(Clone, Default)]
-pub struct RequestQueue<T: Request + Clone + Copy>(pub Vec<RequestQueueEntry<T>>);
+pub struct RequestQueue<T: Request>(pub Vec<RequestQueueEntry<T>>);
 
 #[derive(Clone, Copy, Debug)]
-pub struct RequestQueueEntry<T: Request + Clone + Copy> {
+pub struct RequestQueueEntry<T: Request> {
     pub request: T,
     pub timestamp: BlockTime,
 }
 
-pub trait Request {
+pub trait Request: Clone + Copy + FromBytes + ToBytes + CLTyped {
     fn is_same(&self, rhs: &Self) -> bool;
 }
 
-impl<T: Request + Clone + Copy> RequestQueue<T> {
+impl<T: Request> RequestQueue<T> {
     pub fn push(&mut self, request: T, timestamp: BlockTime) -> Result<()> {
         if self.0.iter().any(|entry| entry.request.is_same(&request)) {
             return Err(Error::MultipleRequests);
@@ -38,5 +39,57 @@ impl<T: Request + Clone + Copy> RequestQueue<T> {
             .partition(|entry| entry.timestamp <= timestamp);
         self.0 = rest;
         older_than
+    }
+}
+
+impl<T: Request> FromBytes for RequestQueue<T> {
+    fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
+        let (len, mut bytes) = u64::from_bytes(bytes)?;
+        let mut queue = Vec::new();
+        for _ in 0..len {
+            let (entry, rest) = RequestQueueEntry::from_bytes(bytes)?;
+            bytes = rest;
+            queue.push(entry);
+        }
+        Ok((RequestQueue(queue), bytes))
+    }
+}
+
+impl<T: Request> ToBytes for RequestQueue<T> {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        let mut bytes = (self.0.len() as u64).to_bytes()?; // TODO: Allocate correct capacity.
+        for entry in &self.0 {
+            bytes.append(&mut entry.to_bytes()?);
+        }
+        Ok(bytes)
+    }
+}
+
+impl<T: Request> CLTyped for RequestQueue<T> {
+    fn cl_type() -> CLType {
+        CLType::List(Box::new(RequestQueueEntry::<T>::cl_type()))
+    }
+}
+
+impl<T: Request> FromBytes for RequestQueueEntry<T> {
+    fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
+        let (request, bytes) = T::from_bytes(bytes)?;
+        let (timestamp, bytes) = BlockTime::from_bytes(bytes)?;
+        let entry = RequestQueueEntry { request, timestamp };
+        Ok((entry, bytes))
+    }
+}
+
+impl<T: Request> ToBytes for RequestQueueEntry<T> {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        Ok((self.request.to_bytes()?.into_iter())
+            .chain(self.timestamp.to_bytes()?)
+            .collect())
+    }
+}
+
+impl<T: Request> CLTyped for RequestQueueEntry<T> {
+    fn cl_type() -> CLType {
+        CLType::Any
     }
 }


### PR DESCRIPTION
For applying system-wide configuration such as `unbonding_delay`, `RequestQueue` is introduced so we can pop delegation, undelegation and redelegation request requested before specific block time, and lazily apply them.

You can test contract inner unit test with the command below.
```sh
cd contracts/hdac-system/pop
# This is for Linux, adjust --target for your system.
cargo test --features std --target x86_64-unknown-linux-gnu contract_queue
```