### PR TITLE
Sanitize the pop contract

### DIFF
--- a/execution-engine/contracts/hdac-system/pop/src/constants.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/constants.rs
@@ -30,6 +30,7 @@ pub(crate) mod methods {
 }
 
 pub(crate) mod consts {
+    pub const SYSTEM_ACCOUNT: [u8; 32] = [0u8; 32];
     pub const DAYS_OF_YEAR: i64 = 365_i64;
     pub const HOURS_OF_DAY: i64 = 24_i64;
     pub const SECONDS_OF_HOUR: i64 = 3600_i64;

--- a/execution-engine/contracts/hdac-system/pop/src/contract_economy.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/contract_economy.rs
@@ -82,7 +82,6 @@ impl ContractClaim {
 
     // prefix: "c"
     // c_{PublicKey}_{ClaimableBalance}
-    #[allow(clippy::or_fun_call)]
     pub fn read_commission() -> Result<Commissions> {
         let mut commissions = BTreeMap::new();
         for (name, _) in runtime::list_named_keys() {
@@ -120,7 +119,6 @@ impl ContractClaim {
 
     // prefix: "c"
     // c_{PublicKey}_{ClaimableBalance}
-    #[allow(clippy::or_fun_call)]
     pub fn write_commission(commissions: &Commissions) {
         // Encode the stakes as a set of uref names.
         let mut new_urefs: BTreeSet<String> = commissions
@@ -157,7 +155,6 @@ impl ContractClaim {
 
     // prefix: "r"
     // r_{PublicKey}_{ClaimableBalance}
-    #[allow(clippy::or_fun_call)]
     pub fn read_reward() -> Result<Rewards> {
         let mut rewards = BTreeMap::new();
         for (name, _) in runtime::list_named_keys() {
@@ -195,7 +192,6 @@ impl ContractClaim {
 
     // prefix: "r"
     // r_{PublicKey}_{ClaimableBalance}
-    #[allow(clippy::or_fun_call)]
     pub fn write_reward(rewards: &Rewards) {
         // Encode the stakes as a set of uref names.
         let mut new_urefs: BTreeSet<String> = rewards

--- a/execution-engine/contracts/hdac-system/pop/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/lib.rs
@@ -60,13 +60,6 @@ pub fn delegate() {
         // Type of this method: `fn step()`
         methods::METHOD_STEP => {
             // This is called by the system in every block.
-            let maybe_system_user: PublicKey = runtime::get_caller();
-
-            // system user: PublicKey([0, 0, 0, ... , 0]) 32 of 0s
-            if maybe_system_user.value() != [0u8; 32] {
-                runtime::revert(ApiError::NoAccessRights);
-            }
-
             pop_contract.step().unwrap_or_revert();
         }
         // Type of this method: `fn get_payment_purse() -> PurseId`
@@ -171,13 +164,6 @@ pub fn delegate() {
             pop_contract.unvote(user, dapp, amount).unwrap_or_revert();
         }
         methods::METHOD_WRITE_GENESIS_TOTAL_SUPPLY => {
-            let maybe_system_user: PublicKey = runtime::get_caller();
-
-            // system user: PublicKey([0, 0, 0, ... , 0]) 32 of 0s
-            if maybe_system_user != PublicKey::new([0u8; 32]) {
-                runtime::revert(ApiError::NoAccessRights);
-            }
-
             let genesis_total_supply: U512 = runtime::get_arg(1)
                 .unwrap_or_revert_with(ApiError::MissingArgument)
                 .unwrap_or_revert_with(ApiError::InvalidArgument);

--- a/execution-engine/contracts/hdac-system/pop/src/pop_contract.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/pop_contract.rs
@@ -37,21 +37,23 @@ impl ProofOfStake<ContractMint, ContractQueue, ContractRuntime, ContractStakes>
     }
 
     fn step(&self) -> Result<()> {
-        Err(Error::NotSupportedFunc)
+        // let blocktime = runtime::get_blocktime();
+        // self.step_undelegation(blocktime);
+        // self.step_redelegation(blocktime);
+        let caller = runtime::get_caller();
+
+        if caller.value() != consts::SYSTEM_ACCOUNT {
+            return Err(Error::SystemFunctionCalledByUserAccount);
+        }
+
+        self.distribute()?;
+        self.step_claim()?;
+
+        Ok(())
     }
 }
 
 impl ProofOfProfessionContract {
-    pub fn step(&self) -> Result<()> {
-        // let blocktime = runtime::get_blocktime();
-        // self.step_undelegation(blocktime);
-        // self.step_redelegation(blocktime);
-        let _ = self.distribute();
-        let _ = self.step_claim();
-
-        Ok(())
-    }
-
     pub fn delegate(
         &self,
         delegator: PublicKey,
@@ -281,6 +283,12 @@ impl ProofOfProfessionContract {
     }
 
     pub fn write_genesis_total_supply(&self, genesis_total_supply: &U512) -> Result<()> {
+        let caller = runtime::get_caller();
+
+        if caller.value() != consts::SYSTEM_ACCOUNT {
+            return Err(Error::SystemFunctionCalledByUserAccount);
+        }
+
         let mut total_supply = ContractClaim::read_total_supply()?;
         total_supply.add(genesis_total_supply);
         ContractClaim::write_total_supply(&total_supply);

--- a/execution-engine/contracts/hdac-system/pop/src/pop_contract.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/pop_contract.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::clone_on_copy)]
-
 use alloc::collections::BTreeMap;
 use contract::{
     contract_api::{runtime, system},
@@ -401,17 +399,17 @@ impl ProofOfProfessionContract {
         let validator_commission = commissions
             .0
             .get(validator)
+            .cloned()
             .unwrap_or_revert_with(Error::RewardNotFound);
-        let validator_commission_clone = validator_commission.clone();
-        commissions.claim_commission(validator, &validator_commission_clone);
+
+        commissions.claim_commission(validator, &validator_commission);
         ContractClaim::write_commission(&commissions);
 
         let mut claim_requests = ContractQueue::read_claim_requests();
 
-        claim_requests.0.push(ClaimRequest::Commission(
-            *validator,
-            validator_commission_clone,
-        ));
+        claim_requests
+            .0
+            .push(ClaimRequest::Commission(*validator, validator_commission));
 
         ContractQueue::write_claim_requests(claim_requests);
 
@@ -425,16 +423,16 @@ impl ProofOfProfessionContract {
         let user_reward = rewards
             .0
             .get(user)
+            .cloned()
             .unwrap_or_revert_with(Error::RewardNotFound);
-        let user_reward_clone = user_reward.clone();
-        rewards.claim_rewards(user, &user_reward_clone);
+        rewards.claim_rewards(user, &user_reward);
         ContractClaim::write_reward(&rewards);
 
         let mut claim_requests = ContractQueue::read_claim_requests();
 
         claim_requests
             .0
-            .push(ClaimRequest::Reward(*user, user_reward_clone));
+            .push(ClaimRequest::Reward(*user, user_reward));
 
         ContractQueue::write_claim_requests(claim_requests);
 


### PR DESCRIPTION
* Remove the unnecessary lint suppressions.
* Correct the error code with more adequate error(`ApiError::NoAccessRight` -> `SystemFunctionCalledByUserAccount`) and make the ignored errors to be propagated.