### PR TITLE
feat: using key serialized data in dapp key

### DIFF
--- a/execution-engine/contracts/hdac-system/pop-install/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop-install/src/lib.rs
@@ -134,11 +134,7 @@ pub extern "C" fn call() {
                 if split_key[1].len() != 64 {
                     runtime::revert(Error::VoteKeyDeserializationFailed);
                 }
-                if !((split_key[2].len() == 66) // Account, Hash
-                    || (split_key[2].len() == 68) // Uref
-                    || (split_key[2].len() == 130))
-                // Local
-                {
+                if !((split_key[2].len() == 66) || (split_key[2].len() == 68)) {
                     runtime::revert(Error::VoteKeyDeserializationFailed);
                 }
 

--- a/execution-engine/contracts/hdac-system/pop-install/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop-install/src/lib.rs
@@ -131,9 +131,17 @@ pub extern "C" fn call() {
                 if split_key.len() != 4 {
                     runtime::revert(Error::VoteKeyDeserializationFailed);
                 }
-                if split_key[1].len() != 64 && split_key[2].len() != 64 {
+                if split_key[1].len() != 64 {
                     runtime::revert(Error::VoteKeyDeserializationFailed);
                 }
+                if !((split_key[2].len() == 66) // Account, Hash
+                    || (split_key[2].len() == 68) // Uref
+                    || (split_key[2].len() == 130))
+                // Local
+                {
+                    runtime::revert(Error::VoteKeyDeserializationFailed);
+                }
+
                 match U512::from_dec_str(split_key[3]) {
                     Ok(amount) => {
                         match voters.get_mut(split_key[1]) {

--- a/execution-engine/engine-tests/src/test/hdac_system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/hdac_system_contracts/genesis.rs
@@ -7,7 +7,7 @@ use engine_test_support::internal::{
     utils, InMemoryWasmTestBuilder, DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT,
     POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
-use types::{account::PublicKey, Key, ProtocolVersion, U512};
+use types::{account::PublicKey, bytesrepr::ToBytes, Key, ProtocolVersion, U512};
 
 const MINT_INSTALL: &str = MINT_INSTALL_CONTRACT;
 const POS_INSTALL: &str = POS_INSTALL_CONTRACT;
@@ -367,6 +367,8 @@ fn should_vote_is_less_than_delegate() {
         )
     };
 
+    let hash = Key::to_bytes(&Key::Hash(ACCOUNT_1_ADDR.value()))
+        .expect("VoteKey serialization cannot fail");
     let state_infos = vec![
         format_args!(
             "d_{}_{}_{}",
@@ -378,7 +380,7 @@ fn should_vote_is_less_than_delegate() {
         format_args!(
             "a_{}_{}_{}",
             base16::encode_lower(&ACCOUNT_1_ADDR.as_bytes()),
-            base16::encode_lower(&ACCOUNT_1_ADDR.as_bytes()),
+            base16::encode_lower(&hash),
             1_000_000.to_string()
         )
         .to_string(),
@@ -408,6 +410,8 @@ fn should_fail_vote_is_more_than_delegate() {
         )
     };
 
+    let hash = Key::to_bytes(&Key::Hash(ACCOUNT_1_ADDR.value()))
+        .expect("VoteKey serialization cannot fail");
     let state_infos = vec![
         format_args!(
             "d_{}_{}_{}",
@@ -419,7 +423,7 @@ fn should_fail_vote_is_more_than_delegate() {
         format_args!(
             "a_{}_{}_{}",
             base16::encode_lower(&ACCOUNT_1_ADDR.as_bytes()),
-            base16::encode_lower(&ACCOUNT_1_ADDR.as_bytes()),
+            base16::encode_lower(&hash),
             2_000_001.to_string()
         )
         .to_string(),

--- a/execution-engine/engine-tests/src/test/hdac_system_contracts/proof_of_stake/votes.rs
+++ b/execution-engine/engine-tests/src/test/hdac_system_contracts/proof_of_stake/votes.rs
@@ -6,7 +6,7 @@ use engine_test_support::{
     internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
     DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, ApiError, Key, U512};
+use types::{account::PublicKey, bytesrepr::ToBytes, ApiError, Key, U512};
 
 const CONTRACT_POS_VOTE: &str = "pos_delegation.wasm";
 
@@ -135,10 +135,12 @@ fn should_run_successful_vote_and_unvote_after_bonding() {
     );
 
     // that validator should be a_{dApp_pubkey}_{user_pubkey}_{voted_amount}
+    let hash = Key::to_bytes(&Key::Hash(ACCOUNT_1_ADDR_DAPP_1.value()))
+        .expect("VoteKey serialization cannot fail");
     let lookup_key_vote = format!(
         "a_{}_{}_{}",
         base16::encode_lower(ACCOUNT_3_ADDR_USER_1.as_bytes()),
-        base16::encode_lower(ACCOUNT_1_ADDR_DAPP_1.as_bytes()),
+        base16::encode_lower(&hash),
         ACCOUNT_3_VOTE_AMOUNT
     );
     assert!(pos_contract.named_keys().contains_key(&lookup_key_vote));


### PR DESCRIPTION
Using to key serialized data is used for the state value to distinguish the type of account, hash, uref, and local.