### PR TITLE
fix: delegate flow

### DIFF
--- a/execution-engine/contracts/hdac-system/client-api-proxy/src/client_api/mod.rs
+++ b/execution-engine/contracts/hdac-system/client-api-proxy/src/client_api/mod.rs
@@ -173,21 +173,7 @@ impl Api {
             Self::Delegate(validator, amount) => {
                 let pos_ref = system::get_proof_of_stake();
 
-                let source_purse = account::get_main_purse();
-                let bonding_purse = system::create_purse();
-
-                system::transfer_from_purse_to_purse(source_purse, bonding_purse, *amount)
-                    .unwrap_or_revert();
-
-                runtime::call_contract(
-                    pos_ref,
-                    (
-                        method_names::pos::DELEGATE,
-                        *validator,
-                        *amount,
-                        bonding_purse,
-                    ),
-                )
+                runtime::call_contract(pos_ref, (method_names::pos::DELEGATE, *validator, *amount))
             }
             Self::Undelegate(validator, amount) => {
                 let pos_ref = system::get_proof_of_stake();

--- a/execution-engine/contracts/hdac-system/pop/src/lib.rs
+++ b/execution-engine/contracts/hdac-system/pop/src/lib.rs
@@ -94,9 +94,6 @@ pub fn delegate() {
             let amount: U512 = runtime::get_arg(2)
                 .unwrap_or_revert_with(ApiError::MissingArgument)
                 .unwrap_or_revert_with(ApiError::InvalidArgument);
-            // let source_uref: URef = runtime::get_arg(3)
-            // .unwrap_or_revert_with(ApiError::MissingArgument)
-            // .unwrap_or_revert_with(ApiError::InvalidArgument);
             pop_contract
                 .delegate(delegator, validator, amount)
                 .unwrap_or_revert();


### PR DESCRIPTION
Removed logic that sends to `bonding_purse` when delegate.

Related to https://github.com/hdac-io/friday/issues/156